### PR TITLE
Update safe deployments 

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,10 +78,10 @@
   },
   "dependencies": {
     "@gnosis.pm/safe-contracts": "^1.3.0",
-    "@gnosis.pm/safe-deployments": "^1.0.0",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.0-rc.1",
     "@openzeppelin/hardhat-upgrades": "^1.21.0",
+    "@safe-global/safe-deployments": "^1.22.0",
     "cli-table3": "^0.6.3",
     "colors": "^1.4.0",
     "cpr-promise": "^0.2.6",

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,13 +3,13 @@ import { dirname, resolve } from "path";
 
 import { VoidSigner } from "@ethersproject/abstract-signer";
 import { BaseProvider, JsonRpcProvider } from "@ethersproject/providers";
-import {
-  getProxyFactoryDeployment,
-  getSafeSingletonDeployment,
-} from "@gnosis.pm/safe-deployments";
 import { impersonateAccount } from "@nomicfoundation/hardhat-network-helpers";
 import { getTransparentUpgradeableProxyFactory } from "@openzeppelin/hardhat-upgrades/dist/utils";
 import { hashBytecodeWithoutMetadata } from "@openzeppelin/upgrades-core";
+import {
+  getProxyFactoryDeployment,
+  getSafeSingletonDeployment,
+} from "@safe-global/safe-deployments";
 import colors from "colors/safe";
 import { prompt } from "enquirer";
 import { BigNumber, Contract, ContractFactory } from "ethers";

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,6 +9,7 @@ import { hashBytecodeWithoutMetadata } from "@openzeppelin/upgrades-core";
 import {
   getProxyFactoryDeployment,
   getSafeSingletonDeployment,
+  getSafeL2SingletonDeployment,
 } from "@safe-global/safe-deployments";
 import colors from "colors/safe";
 import { prompt } from "enquirer";
@@ -673,9 +674,10 @@ export function getGnosisSafeSingletonAddress(config: DeployConfig): string {
   }
 
   let chainId = getSourceChainId(config);
-  let deployment = getSafeSingletonDeployment({
-    network: chainId.toString(),
-  });
+  let deployment =
+    getSafeL2SingletonDeployment({
+      network: chainId.toString(),
+    }) ?? getSafeSingletonDeployment({ network: chainId.toString() });
   if (!deployment) {
     throw new HardhatPluginError(
       PLUGIN_NAME,

--- a/yarn.lock
+++ b/yarn.lock
@@ -509,13 +509,6 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.3.0.tgz#316741a7690d8751a1f701538cfc9ec80866eedc"
   integrity sha512-1p+1HwGvxGUVzVkFjNzglwHrLNA67U/axP0Ct85FzzH8yhGJb4t9jDjPYocVMzLorDoWAfKicGy1akPY9jXRVw==
 
-"@gnosis.pm/safe-deployments@^1.0.0":
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.17.0.tgz#52a7b0e75c08b4a829f491b594e2babbdd6606c5"
-  integrity sha512-vfl13IuSMqJZxTPraRcKZqJcaSCDWTt/JXH6VURa8LHMYATOqd96IGbqqOKRPAgSzAyXpA2thOD4YUQ0X8XKyQ==
-  dependencies:
-    semver "^7.3.7"
-
 "@humanwhocodes/config-array@^0.10.5":
   version "0.10.6"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.6.tgz#70b53559baf544dc2cc5eea6082bf90467ccb1dc"
@@ -857,6 +850,13 @@
     ethereumjs-util "^7.0.3"
     proper-lockfile "^4.1.1"
     solidity-ast "^0.4.15"
+
+"@safe-global/safe-deployments@^1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.22.0.tgz#4214ac5a9ebcad7cdbf5f641b0728bc0e497286e"
+  integrity sha512-SmbeCRMlcO/EONxbV6nP6pM/60q0NIHVezxx5FMv0dIAkDffdbm25reonKlOk3AJYW1b/c6pZA0RbWDwFSJEkQ==
+  dependencies:
+    semver "^7.3.7"
 
 "@scure/base@~1.1.0":
   version "1.1.1"


### PR DESCRIPTION
We should default to safe creation to l2singleton not the old singleton for network. If we dont we may get (this mainly has to do with events)
- old singleton [here](https://github.com/safe-global/safe-deployments/blob/main/src/assets/v1.3.0/gnosis_safe.json)
- l2 singleton [here](https://github.com/safe-global/safe-deployments/blob/main/src/assets/v1.3.0/gnosis_safe_l2.json)

<img width="664" alt="Screenshot 2023-04-24 at 17 15 24" src="https://user-images.githubusercontent.com/8165111/234011372-6170b091-ca6f-4ab2-be00-70b0d6bcfe52.png">

You can see [here](https://polygonscan.com/tx/0x71b5b7acf16c89c6335ca1d1c691ef588fb7841ad7e619eab68c8f4710523cd6) for a transaction created with the old singleton 

<img width="1364" alt="Screenshot 2023-04-24 at 17 33 32" src="https://user-images.githubusercontent.com/8165111/233958342-9158f4a8-e10f-401b-9ee2-2fc546732776.png">

Rather it should be created via L2 singleton (although this is mainnet) like [here](https://etherscan.io/tx/0xdeb34cd84afb48ee99d64483b26e0d54c9f825fdcac1b63572001f11a72ba656)


![Screenshot 2023-04-24 at 21 29 52](https://user-images.githubusercontent.com/8165111/234012280-3189e59c-1166-4443-8a54-096332145625.png)

